### PR TITLE
Default type params

### DIFF
--- a/builder-pattern-macro/src/attributes.rs
+++ b/builder-pattern-macro/src/attributes.rs
@@ -1,4 +1,5 @@
 use bitflags::bitflags;
+use proc_macro2::TokenTree;
 use syn::{Attribute, Expr, Ident, Meta, NestedMeta};
 
 bitflags! {
@@ -24,6 +25,15 @@ pub struct FieldAttributes {
     pub setters: Setters,
     pub vis: FieldVisibility,
     pub replace_generics: Vec<Ident>,
+}
+
+pub fn ident_add_underscore(ident: &Ident) -> Ident {
+    let ident_ = ident.to_string() + "_";
+    Ident::new(&ident_, ident.span())
+}
+
+pub fn ident_add_underscore_tree(ident: &Ident) -> TokenTree {
+    TokenTree::Ident(ident_add_underscore(ident))
 }
 
 impl Default for FieldAttributes {

--- a/builder-pattern-macro/src/attributes.rs
+++ b/builder-pattern-macro/src/attributes.rs
@@ -24,7 +24,7 @@ pub struct FieldAttributes {
     pub documents: Vec<Attribute>,
     pub setters: Setters,
     pub vis: FieldVisibility,
-    pub replace_generics: Vec<Ident>,
+    pub infer: Vec<Ident>,
 }
 
 pub fn ident_add_underscore(ident: &Ident) -> Ident {
@@ -45,7 +45,7 @@ impl Default for FieldAttributes {
             documents: vec![],
             setters: Setters::VALUE,
             vis: FieldVisibility::Default,
-            replace_generics: vec![],
+            infer: vec![],
         }
     }
 }
@@ -87,7 +87,7 @@ impl From<Vec<Attribute>> for FieldAttributes {
                 attributes.documents = get_documents(&attrs);
             } else if attr.path.is_ident("setter") {
                 parse_setters(attr, &mut attributes)
-            } else if attr.path.is_ident("replace_generics") {
+            } else if attr.path.is_ident("infer") {
                 parse_replace_generics(attr, &mut attributes)
             }
         });
@@ -145,15 +145,15 @@ fn parse_setters(attr: &Attribute, attributes: &mut FieldAttributes) {
 
 fn parse_replace_generics(attr: &Attribute, attributes: &mut FieldAttributes) {
     let meta = attr.parse_meta().unwrap();
-    let mut replace_generics = vec![];
+    let mut infer = vec![];
     if let Meta::List(l) = meta {
         let it = l.nested.iter();
         it.for_each(|m| {
             if let NestedMeta::Meta(Meta::Path(p)) = m {
                 if let Some(ident) = p.get_ident() {
-                    replace_generics.push(ident.clone());
+                    infer.push(ident.clone());
                 } else {
-                    unimplemented!("Invalid replace_generics, write a type parameter.")
+                    unimplemented!("Invalid infer, write a type parameter.")
                 }
             } else {
                 unimplemented!("Invalid setter.")
@@ -162,7 +162,7 @@ fn parse_replace_generics(attr: &Attribute, attributes: &mut FieldAttributes) {
     } else {
         unimplemented!("Invalid setter.")
     }
-    attributes.replace_generics = replace_generics;
+    attributes.infer = infer;
 }
 
 pub fn get_documents(attrs: &[Attribute]) -> Vec<Attribute> {

--- a/builder-pattern-macro/src/attributes.rs
+++ b/builder-pattern-macro/src/attributes.rs
@@ -24,6 +24,7 @@ pub struct FieldAttributes {
     pub documents: Vec<Attribute>,
     pub setters: Setters,
     pub vis: FieldVisibility,
+    pub late_bound_default: bool,
     pub infer: Vec<Ident>,
 }
 
@@ -45,6 +46,7 @@ impl Default for FieldAttributes {
             documents: vec![],
             setters: Setters::VALUE,
             vis: FieldVisibility::Default,
+            late_bound_default: false,
             infer: vec![],
         }
     }
@@ -74,6 +76,7 @@ impl From<Vec<Attribute>> for FieldAttributes {
                     unimplemented!("Duplicated `hidden` attributes.")
                 }
                 attributes.vis = FieldVisibility::Hidden;
+                attributes.late_bound_default = true;
             } else if attr.path.is_ident("public") {
                 if attributes.vis != FieldVisibility::Default {
                     unimplemented!("Duplicated `public` attributes.")
@@ -90,6 +93,7 @@ impl From<Vec<Attribute>> for FieldAttributes {
             } else if attr.path.is_ident("infer") {
                 parse_replace_generics(attr, &mut attributes)
             }
+            // TODO: rebind default (syntactically) in infer() setters
         });
         match attributes.validate() {
             Ok(_) => attributes,

--- a/builder-pattern-macro/src/attributes.rs
+++ b/builder-pattern-macro/src/attributes.rs
@@ -25,7 +25,6 @@ pub struct FieldAttributes {
     pub setters: Setters,
     pub vis: FieldVisibility,
     pub late_bound_default: bool,
-    pub use_inferred: Vec<Ident>,
     pub infer: Vec<Ident>,
 }
 
@@ -48,7 +47,6 @@ impl Default for FieldAttributes {
             setters: Setters::VALUE,
             vis: FieldVisibility::Default,
             late_bound_default: false,
-            use_inferred: vec![],
             infer: vec![],
         }
     }
@@ -94,8 +92,6 @@ impl From<Vec<Attribute>> for FieldAttributes {
                 parse_setters(attr, &mut attributes)
             } else if attr.path.is_ident("infer") {
                 parse_infer(attr, &mut attributes)
-            } else if attr.path.is_ident("use_inferred") {
-                parse_use_inferred(attr, &mut attributes)
             } else if attr.path.is_ident("late_bound_default") {
                 attributes.late_bound_default = true;
             }
@@ -172,28 +168,6 @@ fn parse_infer(attr: &Attribute, attributes: &mut FieldAttributes) {
         unimplemented!("Invalid setter.")
     }
     attributes.infer = params;
-}
-
-fn parse_use_inferred(attr: &Attribute, attributes: &mut FieldAttributes) {
-    let meta = attr.parse_meta().unwrap();
-    let mut params = vec![];
-    if let Meta::List(l) = meta {
-        let it = l.nested.iter();
-        it.for_each(|m| {
-            if let NestedMeta::Meta(Meta::Path(p)) = m {
-                if let Some(ident) = p.get_ident() {
-                    params.push(ident.clone());
-                } else {
-                    unimplemented!("Invalid use_infer, write a type parameter.")
-                }
-            } else {
-                unimplemented!("Invalid setter.")
-            }
-        });
-    } else {
-        unimplemented!("Invalid setter.")
-    }
-    attributes.use_inferred = params;
 }
 
 pub fn get_documents(attrs: &[Attribute]) -> Vec<Attribute> {

--- a/builder-pattern-macro/src/builder/builder_decl.rs
+++ b/builder-pattern-macro/src/builder/builder_decl.rs
@@ -24,7 +24,7 @@ impl<'a> ToTokens for BuilderDecl<'a> {
 
         let impl_tokens = self.input.tokenize_impl();
         let all_generics = self.input.all_generics().collect::<Vec<_>>();
-        let ty_tokens = self.input.tokenize_types();
+        let ty_tokens = self.input.tokenize_types(&[]);
 
         let fn_lifetime = self.input.fn_lifetime();
         let builder_fields = self.input.builder_fields(&fn_lifetime);

--- a/builder-pattern-macro/src/builder/builder_decl.rs
+++ b/builder-pattern-macro/src/builder/builder_decl.rs
@@ -41,7 +41,7 @@ impl<'a> ToTokens for BuilderDecl<'a> {
                 AsyncFieldMarker,
                 ValidatorOption
             > #where_clause {
-                _phantom: ::core::marker::PhantomData<(
+                __builder_phantom: ::core::marker::PhantomData<(
                     #ty_tokens
                     #(#all_generics,)*
                     AsyncFieldMarker,

--- a/builder-pattern-macro/src/builder/builder_decl.rs
+++ b/builder-pattern-macro/src/builder/builder_decl.rs
@@ -42,6 +42,7 @@ impl<'a> ToTokens for BuilderDecl<'a> {
                 ValidatorOption
             > #where_clause {
                 __builder_phantom: ::core::marker::PhantomData<(
+                    &#fn_lifetime (),
                     #ty_tokens
                     #(#all_generics,)*
                     AsyncFieldMarker,

--- a/builder-pattern-macro/src/builder/builder_decl.rs
+++ b/builder-pattern-macro/src/builder/builder_decl.rs
@@ -22,9 +22,9 @@ impl<'a> ToTokens for BuilderDecl<'a> {
         let builder_name = self.input.builder_name();
         let where_clause = &self.input.generics.where_clause;
 
-        let impl_tokens = self.input.tokenize_impl();
+        let impl_tokens = self.input.tokenize_impl(&[]);
         let all_generics = self.input.all_generics().collect::<Vec<_>>();
-        let ty_tokens = self.input.tokenize_types(&[]);
+        let ty_tokens = self.input.tokenize_types(&[], false);
 
         let fn_lifetime = self.input.fn_lifetime();
         let builder_fields = self.input.builder_fields(&fn_lifetime);

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -22,7 +22,11 @@ impl<'a> ToTokens for BuilderFunctions<'a> {
             .chain(self.input.optional_fields.iter())
             .map(|f| {
                 let ident = &f.ident;
-                quote! { #ident: self.#ident }
+                if f.attrs.vis == FieldVisibility::Hidden {
+                    quote!{ #ident: None }
+                } else {
+                    quote! { #ident: self.#ident }
+                }
             })
             .collect::<Vec<_>>();
 

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -140,11 +140,8 @@ impl<'a> BuilderFunctions<'a> {
             .iter_mut()
             .for_each(|ty_tokens: &mut TokenStream| {
                 let tokens = std::mem::take(ty_tokens);
-                *ty_tokens = replace_type_params_in(
-                    tokens,
-                    &f.attrs.infer,
-                    &ident_add_underscore_tree,
-                );
+                *ty_tokens =
+                    replace_type_params_in(tokens, &f.attrs.infer, &ident_add_underscore_tree);
             });
         let (arg_type_gen, arg_type) = if f.attrs.use_into {
             (

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -34,8 +34,6 @@ impl<'a> ToTokens for BuilderFunctions<'a> {
                             _ => unreachable!(),
                         }
                     }
-                } else if !f.attrs.use_inferred.is_empty() {
-                    quote! { #ident: None }
                 } else {
                     quote! { #ident: self.#ident }
                 }

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -22,7 +22,7 @@ impl<'a> ToTokens for BuilderFunctions<'a> {
             .chain(self.input.optional_fields.iter())
             .map(|f| {
                 let ident = &f.ident;
-                if f.attrs.vis == FieldVisibility::Hidden {
+                if f.attrs.late_bound_default {
                     quote! { #ident: None }
                 } else {
                     quote! { #ident: self.#ident }

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -180,7 +180,7 @@ impl<'a> BuilderFunctions<'a> {
                         match #v (value.into()) {
                             Ok(value) => Ok(
                                 #builder_name {
-                                    _phantom: ::core::marker::PhantomData,
+                                    __builder_phantom: ::core::marker::PhantomData,
                                     #(#builder_fields),*
                                 }),
                             Err(e) => Err(format!("Validation failed: {:?}", e))
@@ -207,7 +207,7 @@ impl<'a> BuilderFunctions<'a> {
                     },
                     quote! {
                         #builder_name {
-                            _phantom: ::core::marker::PhantomData,
+                            __builder_phantom: ::core::marker::PhantomData,
                             #(#builder_fields),*
                         }
                     },
@@ -284,7 +284,7 @@ impl<'a> BuilderFunctions<'a> {
         };
         let ret_expr_val = quote! {
             #builder_name {
-                _phantom: ::core::marker::PhantomData,
+                __builder_phantom: ::core::marker::PhantomData,
                 #(#builder_fields),*
             }
         };
@@ -383,7 +383,7 @@ impl<'a> BuilderFunctions<'a> {
         };
         let ret_expr_val = quote! {
             #builder_name {
-                _phantom: ::core::marker::PhantomData,
+                __builder_phantom: ::core::marker::PhantomData,
                 #(#builder_fields),*
             }
         };

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -127,13 +127,13 @@ impl<'a> BuilderFunctions<'a> {
         let fn_lifetime = self.input.fn_lifetime();
         let impl_tokens = self.input.tokenize_impl(&[]);
         let ty_tokens = self.input.tokenize_types(&[], false);
-        let ty_tokens_ = self.input.tokenize_types(&f.attrs.replace_generics, false);
+        let ty_tokens_ = self.input.tokenize_types(&f.attrs.infer, false);
         let fn_generics = f.tokenize_replacement_params();
-        let fn_where_clause = self.input.setter_where_clause(&f.attrs.replace_generics);
+        let fn_where_clause = self.input.setter_where_clause(&f.attrs.infer);
         let (other_generics, before_generics, mut after_generics) = self.get_generics(f, index);
         let replaced_ty = replace_type_params_in(
             quote! { #orig_ty },
-            &f.attrs.replace_generics,
+            &f.attrs.infer,
             &ident_add_underscore_tree,
         );
         after_generics
@@ -142,7 +142,7 @@ impl<'a> BuilderFunctions<'a> {
                 let tokens = std::mem::take(ty_tokens);
                 *ty_tokens = replace_type_params_in(
                     tokens,
-                    &f.attrs.replace_generics,
+                    &f.attrs.infer,
                     &ident_add_underscore_tree,
                 );
             });

--- a/builder-pattern-macro/src/builder/builder_functions.rs
+++ b/builder-pattern-macro/src/builder/builder_functions.rs
@@ -24,6 +24,28 @@ impl<'a> ToTokens for BuilderFunctions<'a> {
                 let ident = &f.ident;
                 if f.attrs.late_bound_default {
                     quote! { #ident: None }
+                } else if !f.attrs.use_inferred.is_empty() {
+                    quote! { #ident: None }
+                    // let Some((expr, _)) = f.attrs.default.as_ref() else {
+                    //     return quote!{ #ident: compile_error!("#[use_inferred] without #[default]"), };
+                    // };
+
+                    // rebind to the #[infer]red type by stamping out the default's syntactic
+                    // representation again in this setter method. e.g. `None` can fit in a slot
+                    // for many different Option<T> types. If you change `T` from the default (e.g.
+                    // f64) to an #[infer]red type (e.g. i32) then you as long as the macro writes
+                    // `None` again, we're good.
+                    // quote! {
+                    //     #ident: match self.#ident {
+                    //         Some(::builder_pattern::setter::Setter::Default(_)) => {
+                    //             Some(::builder_pattern::setter::Setter::Value(#expr))
+                    //         }
+                    //         Some(::builder_pattern::setter::Setter::Value(val)) => {
+                    //             Some(::builder_pattern::setter::Setter::Value(val))
+                    //         }
+                    //         _ => unreachable!(),
+                    //     }
+                    // }
                 } else {
                     quote! { #ident: self.#ident }
                 }

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -177,7 +177,7 @@ impl<'a> BuilderImpl<'a> {
         };
         tokens.extend(quote! {
         impl <#fn_lifetime, #impl_tokens #(#optional_generics,)*> #builder_name
-            <#fn_lifetime, #(#lifetimes,)* #ty_tokens #(#satisfied_generics),*, #async_generic, ()>
+            <#fn_lifetime, #(#lifetimes,)* #ty_tokens #(#satisfied_generics,)* #async_generic, ()>
             #where_clause
             {
                 #[allow(dead_code)]

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -103,7 +103,7 @@ impl<'a> BuilderImpl<'a> {
                 struct_init_args.push(ident.to_token_stream());
                 let mk_default_case =
                     |wrap: fn(TokenStream) -> TokenStream| match &f.attrs.default.as_ref() {
-                        Some((expr, setters)) => {
+                        Some((expr, setters)) if f.attrs.late_bound_default => {
                             let expr = match *setters {
                                 Setters::VALUE => quote_spanned! { expr.span() => #expr },
                                 Setters::LAZY => quote_spanned! { expr.span() => (#expr)() },
@@ -112,7 +112,7 @@ impl<'a> BuilderImpl<'a> {
                             let wrapped_expr = wrap(expr);
                             quote! { None => { let val: #substituted_ty = #wrapped_expr; val }, }
                         }
-                        None => quote! { None => unreachable!(), },
+                        _ => quote! { None => unreachable!("required field not set"), },
                     };
 
                 if f.attrs.validator.is_some()

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -3,6 +3,7 @@ use crate::{attributes::Setters, struct_input::StructInput};
 use core::str::FromStr;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
+use syn::spanned::Spanned;
 
 pub struct BuilderImpl<'a> {
     pub input: &'a StructInput,
@@ -90,22 +91,38 @@ impl<'a> BuilderImpl<'a> {
             .for_each(|f| {
                 let ident = &f.ident;
                 struct_init_args.push(ident.to_token_stream());
+                let mk_default_case =
+                    |wrap: fn(TokenStream) -> TokenStream| match &f.attrs.default.as_ref() {
+                        Some((expr, setters)) => {
+                            let expr = match *setters {
+                                Setters::VALUE => quote_spanned! { expr.span() => #expr },
+                                Setters::LAZY => quote_spanned! { expr.span() => (#expr)() },
+                                _ => unimplemented!(),
+                            };
+                            let wrapped_expr = wrap(expr);
+                            quote! { None => #wrapped_expr, }
+                        }
+                        None => quote! { None => unreachable!(), },
+                    };
+
                 if f.attrs.validator.is_some()
                     && !(f.attrs.setters & (Setters::LAZY | Setters::ASYNC)).is_empty()
                 {
                     let async_case = if is_async {
                         quote! {
-                            ::builder_pattern::setter::Setter::Async(f) => Ok(f().await),
-                            ::builder_pattern::setter::Setter::AsyncValidated(f) => f().await,
+                            Some(::builder_pattern::setter::Setter::Async(f)) => Ok(f().await),
+                            Some(::builder_pattern::setter::Setter::AsyncValidated(f)) => f().await,
                         }
                     } else {
                         quote! {_ => unimplemented!()}
                     };
+                    let default_case = mk_default_case(|expr| quote! { Ok(#expr) });
                     validated_init_fields.push(quote! {
-                        let #ident = match match self.#ident.unwrap() {
-                            ::builder_pattern::setter::Setter::Value(v) => Ok(v),
-                            ::builder_pattern::setter::Setter::Lazy(f) => Ok(f()),
-                            ::builder_pattern::setter::Setter::LazyValidated(f) => f(),
+                        let #ident = match match self.#ident {
+                            Some(::builder_pattern::setter::Setter::Value(v)) => Ok(v),
+                            Some(::builder_pattern::setter::Setter::Lazy(f)) => Ok(f()),
+                            Some(::builder_pattern::setter::Setter::LazyValidated(f)) => f(),
+                            #default_case
                             #async_case
                         } {
                             Ok(v) => v,
@@ -115,32 +132,36 @@ impl<'a> BuilderImpl<'a> {
                 } else {
                     let async_case = if is_async {
                         quote! {
-                            ::builder_pattern::setter::Setter::Async(f) => f().await,
+                            Some(::builder_pattern::setter::Setter::Async(f)) => f().await,
                             _ => unimplemented!(),
                         }
                     } else {
                         quote! {_ => unimplemented!()}
                     };
+                    let default_case = mk_default_case(|expr| expr);
                     init_fields.push(quote! {
-                        let #ident = match self.#ident.unwrap() {
-                            ::builder_pattern::setter::Setter::Value(v) => v,
-                            ::builder_pattern::setter::Setter::Lazy(f) => f(),
+                        let #ident = match self.#ident {
+                            Some(::builder_pattern::setter::Setter::Value(v)) => v,
+                            Some(::builder_pattern::setter::Setter::Lazy(f)) => f(),
+                            #default_case
                             #async_case
                         };
                     });
                 }
                 let async_case = if is_async {
                     quote! {
-                        ::builder_pattern::setter::Setter::Async(f) => f().await,
+                        Some(::builder_pattern::setter::Setter::Async(f)) => f().await,
                         _ => unimplemented!(),
                     }
                 } else {
                     quote! {_ => unimplemented!()}
                 };
+                let default_case = mk_default_case(|expr| expr);
                 no_lazy_validation_fields.push(quote! {
-                    let #ident = match self.#ident.unwrap() {
-                        ::builder_pattern::setter::Setter::Value(v) => v,
-                        ::builder_pattern::setter::Setter::Lazy(f) => f(),
+                    let #ident = match self.#ident {
+                        Some(::builder_pattern::setter::Setter::Value(v)) => v,
+                        Some(::builder_pattern::setter::Setter::Lazy(f)) => f(),
+                        #default_case
                         #async_case
                     };
                 });
@@ -159,6 +180,7 @@ impl<'a> BuilderImpl<'a> {
             #where_clause
             {
                 #[allow(dead_code)]
+                #[allow(clippy::redundant_closure_call)]
                 #vis #kw_async fn build(self) -> #ident <#(#lifetimes,)* #ty_tokens> {
                     #(#no_lazy_validation_fields)*
                     #ident {

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -111,7 +111,7 @@ impl<'a> BuilderImpl<'a> {
                             };
                             let wrapped_expr = wrap(expr);
                             quote! {
-                                None => { let val: #ty = #wrapped_expr; val },
+                                None => { let val: #substituted_ty = #wrapped_expr; val },
                                 Some(::builder_pattern::setter::Setter::Default(..)) =>
                                     unreachable!("late-bound optional field was set in new()"),
                             }
@@ -119,9 +119,7 @@ impl<'a> BuilderImpl<'a> {
                         Some((_expr, _setters)) => {
                             quote! {
                                 None => unreachable!("early-bound optional field had no default set in new()"),
-                                Some(::builder_pattern::setter::Setter::Default(t, id_t_d)) => {
-                                    t
-                                }
+                                Some(::builder_pattern::setter::Setter::Default(d)) => d,
                             }
                         }
                         _ => quote! { None => unreachable!("required field not set"), },

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -1,11 +1,9 @@
 use crate::{attributes::Setters, struct_input::StructInput};
 
 use core::str::FromStr;
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::TokenStream;
 use quote::ToTokens;
-use syn::{spanned::Spanned, Type};
-
-use super::builder_functions::replace_type_params_in;
+use syn::spanned::Spanned;
 
 pub struct BuilderImpl<'a> {
     pub input: &'a StructInput,
@@ -80,11 +78,6 @@ impl<'a> BuilderImpl<'a> {
         let impl_tokens = self.input.tokenize_impl(&[]);
         let optional_generics = self.optional_generics().collect::<Vec<_>>();
         let satisfied_generics = self.satified_generics().collect::<Vec<_>>();
-        let defaulted_generics = self.input.defaulted_generics();
-
-        let with_prmdef = |ident: &Ident| self.input.with_param_default(&defaulted_generics, ident);
-        let replace_defaults =
-            |stream: TokenStream| replace_type_params_in(stream, &defaulted_generics, &with_prmdef);
 
         let ty_tokens = self.input.tokenize_types(&[], false);
 

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -77,7 +77,7 @@ impl<'a> BuilderImpl<'a> {
         let impl_tokens = self.input.tokenize_impl();
         let optional_generics = self.optional_generics().collect::<Vec<_>>();
         let satisfied_generics = self.satified_generics().collect::<Vec<_>>();
-        let ty_tokens = self.input.tokenize_types();
+        let ty_tokens = self.input.tokenize_types(&[]);
 
         let mut struct_init_args = vec![];
         let mut validated_init_fields = vec![];

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -110,7 +110,19 @@ impl<'a> BuilderImpl<'a> {
                                 _ => unimplemented!(),
                             };
                             let wrapped_expr = wrap(expr);
-                            quote! { None => { let val: #substituted_ty = #wrapped_expr; val }, }
+                            quote! {
+                                None => { let val: #ty = #wrapped_expr; val },
+                                Some(::builder_pattern::setter::Setter::Default(..)) =>
+                                    unreachable!("late-bound optional field was set in new()"),
+                            }
+                        }
+                        Some((_expr, _setters)) => {
+                            quote! {
+                                None => unreachable!("early-bound optional field had no default set in new()"),
+                                Some(::builder_pattern::setter::Setter::Default(t, id_t_d)) => {
+                                    t
+                                }
+                            }
                         }
                         _ => quote! { None => unreachable!("required field not set"), },
                     };

--- a/builder-pattern-macro/src/builder/builder_impl.rs
+++ b/builder-pattern-macro/src/builder/builder_impl.rs
@@ -74,10 +74,10 @@ impl<'a> BuilderImpl<'a> {
 
         let fn_lifetime = self.input.fn_lifetime();
 
-        let impl_tokens = self.input.tokenize_impl();
+        let impl_tokens = self.input.tokenize_impl(&[]);
         let optional_generics = self.optional_generics().collect::<Vec<_>>();
         let satisfied_generics = self.satified_generics().collect::<Vec<_>>();
-        let ty_tokens = self.input.tokenize_types(&[]);
+        let ty_tokens = self.input.tokenize_types(&[], false);
 
         let mut struct_init_args = vec![];
         let mut validated_init_fields = vec![];

--- a/builder-pattern-macro/src/field.rs
+++ b/builder-pattern-macro/src/field.rs
@@ -1,9 +1,11 @@
+use crate::attributes::ident_add_underscore;
+
 use super::attributes::FieldAttributes;
 
 use core::cmp::Ordering;
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn::{Attribute, Token, Type, Visibility};
+use syn::{token::Comma, Attribute, Token, Type, Visibility};
 
 pub struct Field {
     pub vis: Visibility,
@@ -36,12 +38,13 @@ impl Field {
         if self.attrs.infer.is_empty() {
             return stream;
         }
-        let underscored = self.attrs.infer.iter().map(|ident| {
-            let string = ident.to_string() + "_";
-            Ident::new(&string, ident.span())
-        });
+        let underscored = self
+            .attrs
+            .infer
+            .iter()
+            .map(|ident| ident_add_underscore(ident));
         <Token![<]>::default().to_tokens(&mut stream);
-        stream.append_terminated(underscored, <Token![,]>::default());
+        stream.append_terminated(underscored, Comma::default());
         <Token![>]>::default().to_tokens(&mut stream);
         stream
     }

--- a/builder-pattern-macro/src/field.rs
+++ b/builder-pattern-macro/src/field.rs
@@ -33,10 +33,10 @@ impl Field {
 
     pub fn tokenize_replacement_params(&self) -> TokenStream {
         let mut stream = TokenStream::new();
-        if self.attrs.replace_generics.is_empty() {
+        if self.attrs.infer.is_empty() {
             return stream;
         }
-        let underscored = self.attrs.replace_generics.iter().map(|ident| {
+        let underscored = self.attrs.infer.iter().map(|ident| {
             let string = ident.to_string() + "_";
             Ident::new(&string, ident.span())
         });

--- a/builder-pattern-macro/src/field.rs
+++ b/builder-pattern-macro/src/field.rs
@@ -33,9 +33,9 @@ impl Field {
         }
     }
 
-    pub fn tokenize_replacement_params(&self) -> TokenStream {
+    pub fn tokenize_replacement_params(&self, additional: &[TokenStream]) -> TokenStream {
         let mut stream = TokenStream::new();
-        if self.attrs.infer.is_empty() {
+        if self.attrs.infer.is_empty() && additional.is_empty() {
             return stream;
         }
         let underscored = self
@@ -45,6 +45,7 @@ impl Field {
             .map(|ident| ident_add_underscore(ident));
         <Token![<]>::default().to_tokens(&mut stream);
         stream.append_terminated(underscored, Comma::default());
+        stream.append_terminated(additional.iter(), Comma::default());
         <Token![>]>::default().to_tokens(&mut stream);
         stream
     }

--- a/builder-pattern-macro/src/field.rs
+++ b/builder-pattern-macro/src/field.rs
@@ -1,9 +1,9 @@
 use super::attributes::FieldAttributes;
 
 use core::cmp::Ordering;
-use proc_macro2::Ident;
-use quote::ToTokens;
-use syn::{Attribute, Type, Visibility};
+use proc_macro2::{Ident, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
+use syn::{Attribute, Token, Type, Visibility};
 
 pub struct Field {
     pub vis: Visibility,
@@ -29,6 +29,21 @@ impl Field {
         } else {
             ty_token.to_string()
         }
+    }
+
+    pub fn tokenize_replacement_params(&self) -> TokenStream {
+        let mut stream = TokenStream::new();
+        if self.attrs.replace_generics.is_empty() {
+            return stream;
+        }
+        let underscored = self.attrs.replace_generics.iter().map(|ident| {
+            let string = ident.to_string() + "_";
+            Ident::new(&string, ident.span())
+        });
+        <Token![<]>::default().to_tokens(&mut stream);
+        stream.append_terminated(underscored, <Token![,]>::default());
+        <Token![>]>::default().to_tokens(&mut stream);
+        stream
     }
 }
 

--- a/builder-pattern-macro/src/lib.rs
+++ b/builder-pattern-macro/src/lib.rs
@@ -30,7 +30,8 @@ extern crate proc_macro2;
         into,
         public,
         setter,
-        validator
+        validator,
+        replace_generics,
     )
 )]
 pub fn derive_builder(input: TokenStream) -> TokenStream {

--- a/builder-pattern-macro/src/lib.rs
+++ b/builder-pattern-macro/src/lib.rs
@@ -32,7 +32,6 @@ extern crate proc_macro2;
         setter,
         validator,
         infer,
-        use_inferred,
         late_bound_default,
     )
 )]

--- a/builder-pattern-macro/src/lib.rs
+++ b/builder-pattern-macro/src/lib.rs
@@ -32,6 +32,8 @@ extern crate proc_macro2;
         setter,
         validator,
         infer,
+        use_inferred,
+        late_bound_default,
     )
 )]
 pub fn derive_builder(input: TokenStream) -> TokenStream {

--- a/builder-pattern-macro/src/lib.rs
+++ b/builder-pattern-macro/src/lib.rs
@@ -31,7 +31,7 @@ extern crate proc_macro2;
         public,
         setter,
         validator,
-        replace_generics,
+        infer,
     )
 )]
 pub fn derive_builder(input: TokenStream) -> TokenStream {

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -21,7 +21,7 @@ impl<'a> ToTokens for StructImpl<'a> {
         let lifetimes = self.input.lifetimes();
         let impl_tokens = self.input.tokenize_impl();
         let empty_generics = self.empty_generics();
-        let ty_tokens = self.input.tokenize_types();
+        let ty_tokens = self.input.tokenize_types(&[]);
 
         let fn_lifetime = self.input.fn_lifetime();
 

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -118,22 +118,8 @@ impl<'a> StructImpl<'a> {
                 }
             })
             .chain(self.input.optional_fields.iter().map(|f| {
-                if let (ident, Some((expr, setters))) = (&f.ident, &f.attrs.default.as_ref()) {
-                    match *setters {
-                        Setters::VALUE => quote_spanned! { expr.span() =>
-                            #ident: Some(::builder_pattern::setter::Setter::Value(#expr))
-                        },
-                        Setters::LAZY => {
-                            quote_spanned! { expr.span() =>
-                                #ident: Some(
-                                    ::builder_pattern::setter::Setter::Lazy(
-                                        Box::new(#expr)
-                                    )
-                                )
-                            }
-                        }
-                        _ => unimplemented!(),
-                    }
+                if let (ident, Some((expr, _setters))) = (&f.ident, &f.attrs.default.as_ref()) {
+                    quote_spanned! { expr.span() => #ident: None }
                 } else {
                     unimplemented!()
                 }

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -92,13 +92,17 @@ impl<'a> StructImpl<'a> {
             .chain(self.input.optional_fields.iter().map(|f| {
                 if let (ident, Some((expr, setters))) = (&f.ident, &f.attrs.default.as_ref()) {
                     if f.attrs.late_bound_default {
-                        quote_spanned! { expr.span() => #ident: None }
+                        quote_spanned! { expr.span() => 
+                            #ident: Some(::builder_pattern::setter::Setter::LateBoundDefault(
+                                ::builder_pattern::refl::refl()
+                            ))
+                        }
                     } else {
                         match *setters {
                             Setters::VALUE => quote_spanned! { expr.span() =>
                                 #ident: Some(::builder_pattern::setter::Setter::Default(
                                     #expr,
-                                    // ::builder_pattern::refl::refl()
+                                    ::builder_pattern::refl::refl()
                                 ))
                             },
                             Setters::LAZY => {

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -74,7 +74,7 @@ impl<'a> ToTokens for StructImpl<'a> {
                     #fn_lifetime,
                     #(#lifetimes,)*
                     #ty_tokens
-                    #(#empty_generics),*,
+                    #(#empty_generics,)*
                     (),
                     ()
                 > {

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -1,7 +1,4 @@
-use crate::{
-    attributes::Setters, builder::builder_functions::replace_type_params_in,
-    struct_input::StructInput,
-};
+use crate::{builder::builder_functions::replace_type_params_in, struct_input::StructInput};
 
 use core::str::FromStr;
 use proc_macro2::{Group, Ident, TokenStream, TokenTree};

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -96,7 +96,10 @@ impl<'a> StructImpl<'a> {
                     } else {
                         match *setters {
                             Setters::VALUE => quote_spanned! { expr.span() =>
-                                #ident: Some(::builder_pattern::setter::Setter::Value(#expr))
+                                #ident: Some(::builder_pattern::setter::Setter::Default(
+                                    #expr,
+                                    ::builder_pattern::refl::refl()
+                                ))
                             },
                             Setters::LAZY => {
                                 quote_spanned! { expr.span() =>

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -4,9 +4,9 @@ use crate::{
 };
 
 use core::str::FromStr;
-use proc_macro2::{Group, Ident, TokenStream, TokenTree};
+use proc_macro2::{Ident, TokenStream};
 use quote::ToTokens;
-use syn::{parse_quote, spanned::Spanned, Attribute, Generics};
+use syn::{parse_quote, spanned::Spanned, Attribute};
 
 /// Implementation for the given structure.
 /// It creates a `new` function.
@@ -92,7 +92,7 @@ impl<'a> StructImpl<'a> {
             .chain(self.input.optional_fields.iter().map(|f| {
                 if let (ident, Some((expr, setters))) = (&f.ident, &f.attrs.default.as_ref()) {
                     if f.attrs.late_bound_default {
-                        quote_spanned! { expr.span() => 
+                        quote_spanned! { expr.span() =>
                             #ident: Some(::builder_pattern::setter::Setter::LateBoundDefault(
                                 ::builder_pattern::refl::refl()
                             ))

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -98,7 +98,7 @@ impl<'a> StructImpl<'a> {
                             Setters::VALUE => quote_spanned! { expr.span() =>
                                 #ident: Some(::builder_pattern::setter::Setter::Default(
                                     #expr,
-                                    ::builder_pattern::refl::refl()
+                                    // ::builder_pattern::refl::refl()
                                 ))
                             },
                             Setters::LAZY => {

--- a/builder-pattern-macro/src/struct_impl.rs
+++ b/builder-pattern-macro/src/struct_impl.rs
@@ -80,7 +80,7 @@ impl<'a> ToTokens for StructImpl<'a> {
                 > {
                     #[allow(clippy::redundant_closure_call)]
                     #builder_name {
-                        _phantom: ::core::marker::PhantomData,
+                        __builder_phantom: ::core::marker::PhantomData,
                         #(#builder_init_args),*
                     }
                 }

--- a/builder-pattern-macro/src/struct_input.rs
+++ b/builder-pattern-macro/src/struct_input.rs
@@ -152,7 +152,7 @@ impl StructInput {
 
     /// Tokenize type parameters.
     /// It skips lifetimes and has no outer brackets.
-    pub fn tokenize_types(&self, replace_generics: &[Ident], omit_replaced: bool) -> TokenStream {
+    pub fn tokenize_types(&self, infer: &[Ident], omit_replaced: bool) -> TokenStream {
         let generics = &self.generics;
         let mut tokens = TokenStream::new();
 
@@ -161,7 +161,7 @@ impl StructInput {
         }
         if omit_replaced
             && generics.params.iter().all(|x| match x {
-                GenericParam::Type(param) => replace_generics.contains(&param.ident),
+                GenericParam::Type(param) => infer.contains(&param.ident),
                 GenericParam::Const(_) => false,
                 _ => true,
             })
@@ -187,7 +187,7 @@ impl StructInput {
                 GenericParam::Lifetime(_) => unreachable!(),
                 GenericParam::Type(param) => {
                     // Leave off the type parameter defaults
-                    if replace_generics.contains(&param.ident) {
+                    if infer.contains(&param.ident) {
                         if omit_replaced {
                             continue;
                         }
@@ -207,9 +207,9 @@ impl StructInput {
         tokens
     }
 
-    pub fn setter_where_clause(&self, replace_generics: &[Ident]) -> TokenStream {
+    pub fn setter_where_clause(&self, infer: &[Ident]) -> TokenStream {
         let mut stream = TokenStream::new();
-        if replace_generics.is_empty() {
+        if infer.is_empty() {
             return stream;
         }
         let clauses = self

--- a/builder-pattern-macro/src/struct_input.rs
+++ b/builder-pattern-macro/src/struct_input.rs
@@ -173,19 +173,9 @@ impl StructInput {
             return tokens;
         }
 
-        let mut trailing_or_empty = true;
-        for param in generics.params.pairs() {
-            if let GenericParam::Lifetime(_) = *param.value() {
-                trailing_or_empty = param.punct().is_some();
-            }
-        }
         for param in generics.params.pairs() {
             if let GenericParam::Lifetime(_) = **param.value() {
                 continue;
-            }
-            if !trailing_or_empty {
-                <Token![,]>::default().to_tokens(&mut tokens);
-                trailing_or_empty = true;
             }
             match *param.value() {
                 GenericParam::Lifetime(_) => unreachable!(),
@@ -205,9 +195,8 @@ impl StructInput {
                     param.ident.to_tokens(&mut tokens);
                 }
             }
-            param.punct().to_tokens(&mut tokens);
+            Comma::default().to_tokens(&mut tokens);
         }
-        <Token![,]>::default().to_tokens(&mut tokens);
         tokens
     }
 

--- a/builder-pattern-macro/src/struct_input.rs
+++ b/builder-pattern-macro/src/struct_input.rs
@@ -17,7 +17,7 @@ use syn::{
     AttrStyle, Attribute, Data, DeriveInput, Fields, GenericParam, Generics, Lifetime, Token,
     VisPublic, Visibility,
 };
-use syn::{Path, PredicateType, Type, TypePath, WhereClause, WherePredicate};
+use syn::{WhereClause, WherePredicate};
 
 pub struct StructInput {
     pub vis: Visibility,

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -9,8 +9,12 @@ struct Op<T = &'static str> {
 }
 
 fn main() {
+    use std::any::{Any, TypeId};
     // Should be inferred as Op<&'static str>, i.e. the macro should notice the defaulted type param.
-    let _ = Op::new().build();
+    let a = Op::new().build();
+    assert_eq!(Any::type_id(&a), TypeId::of::<Op<&'static str>>());
+
     // Should be inferred as Op<i32>
-    let _ = Op::new().optional_field(Some(5i32)).build();
+    let a = Op::new().optional_field(Some(5i32)).build();
+    assert_eq!(Any::type_id(&a), TypeId::of::<Op<i32>>());
 }

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -1,0 +1,16 @@
+use builder_pattern::Builder;
+
+#[allow(unused)]
+#[derive(Builder)]
+struct Op<T = &'static str> {
+    #[replace_generics(T)]
+    #[default(None)]
+    optional_field: Option<T>,
+}
+
+fn main() {
+    // Should be inferred as Op<&'static str>, i.e. the macro should notice the defaulted type param.
+    let _ = Op::new().build();
+    // Should be inferred as Op<i32>
+    let _ = Op::new().optional_field(Some(5i32)).build();
+}

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -51,7 +51,7 @@ where
     #[default(|r, _t| r)]
     optional: F2,
     #[hidden]
-    #[default_lazy(|| PhantomData)]
+    #[default(PhantomData)]
     phantom: PhantomData<(T, R)>,
 }
 

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -109,7 +109,10 @@ fn infer_using_fold() {
     let _ = fold_with_closure(
         core::iter::once(&5i32),
         0,
-        DefaultedClosure::new().mandatory(|acc, &x| acc + x).build(),
+        DefaultedClosure::new()
+            .mandatory(|acc, &x| acc + x)
+            .optional(|_acc, &x| x)
+            .build(),
     );
 }
 

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -3,7 +3,7 @@ use builder_pattern::Builder;
 #[allow(unused)]
 #[derive(Builder)]
 struct Op<T = &'static str> {
-    #[replace_generics(T)]
+    #[infer(T)]
     #[default(None)]
     optional_field: Option<T>,
 }

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -48,6 +48,7 @@ where
 {
     mandatory: F1,
     #[infer(F2)]
+    #[late_bound_default]
     #[default(|r, _t| r)]
     optional: F2,
     #[hidden]

--- a/builder-pattern/examples/default-generics.rs
+++ b/builder-pattern/examples/default-generics.rs
@@ -1,20 +1,83 @@
 use builder_pattern::Builder;
+use std::any::{Any, TypeId};
+use std::borrow::Borrow;
+use std::marker::PhantomData;
 
 #[allow(unused)]
 #[derive(Builder)]
-struct Op<T = &'static str> {
+struct Op<T = f64> {
     #[infer(T)]
     #[default(None)]
     optional_field: Option<T>,
 }
 
-fn main() {
-    use std::any::{Any, TypeId};
-    // Should be inferred as Op<&'static str>, i.e. the macro should notice the defaulted type param.
+fn defaulted() {
+    // Should be inferred as Op<f64>, i.e. the macro should notice the defaulted type param.
     let a = Op::new().build();
-    assert_eq!(Any::type_id(&a), TypeId::of::<Op<&'static str>>());
+    assert_eq!(a.type_id(), TypeId::of::<Op<f64>>());
+}
 
+fn override_default() {
     // Should be inferred as Op<i32>
     let a = Op::new().optional_field(Some(5i32)).build();
-    assert_eq!(Any::type_id(&a), TypeId::of::<Op<i32>>());
+    assert_eq!(a.type_id(), TypeId::of::<Op<i32>>());
+}
+
+#[allow(unused)]
+#[derive(Builder)]
+struct IterExtra<T, I = Vec<T>>
+where
+    I: IntoIterator<Item = T>,
+{
+    single: T,
+    #[default(None)]
+    extra: Option<I>,
+}
+
+fn inferred() {
+    let a = IterExtra::new().single(1).build();
+    assert_eq!(a.type_id(), TypeId::of::<IterExtra<i32, Vec<i32>>>());
+}
+
+#[allow(unused)]
+#[derive(Builder)]
+struct DefaultedClosure<T, R, F = fn(R, &T) -> R>
+where
+    F: for<'a> FnMut(R, &T) -> R,
+{
+    #[infer(F)]
+    f: Option<F>,
+    #[hidden]
+    #[default(PhantomData)]
+    phantom: PhantomData<(T, R)>,
+}
+
+trait Callable<T, R> {
+    fn call_fn(&mut self, r: R, t: &T) -> R;
+}
+impl<T, R, F> Callable<T, R> for DefaultedClosure<T, R, F>
+where
+    F: for<'a> FnMut(R, &T) -> R,
+{
+    fn call_fn(&mut self, r: R, t: &T) -> R {
+        if let Some(f) = &mut self.f {
+            f(r, t)
+        } else {
+            r
+        }
+    }
+}
+
+fn infer_f_t() {
+    let mut a = DefaultedClosure::new()
+        .f(Some(|acc, x: &_| acc + x))
+        .build();
+    let called: i32 = a.call_fn(5, &5);
+}
+
+fn main() {
+    defaulted();
+    override_default();
+    inferred();
+    infer_f_t();
 }

--- a/builder-pattern/examples/default-infer.rs
+++ b/builder-pattern/examples/default-infer.rs
@@ -1,18 +1,38 @@
 use builder_pattern::Builder;
-use std::marker::PhantomData;
 
 #[allow(unused)]
 #[derive(Builder)]
-struct Inferred<A = f64, B = String, F: FnMut(B) -> B = fn(B) -> B> {
-    #[infer(A)]
-    a: A,
-    #[infer(B)]
-    b: B,
+struct LateBound<A, B, F: FnMut(B) -> B = fn(B) -> B> {
+    field_a: A,
+    field_b: B,
     #[late_bound_default]
     #[default(|x| x)]
-    b_default: F,
+    transform_b: F,
+}
+
+impl<A, B> LateBound<A, B>
+where
+    B: Clone,
+{
+    fn get_b(&self) -> B {
+        (self.transform_b)(self.field_b.clone())
+    }
+}
+
+fn with() {
+    let l = LateBound::new()
+        .field_a(String::new())
+        .field_b(5)
+        .transform_b(|x| x + 10)
+        .build();
+    assert_eq!(l.get_b(), 15);
+}
+fn without() {
+    let l = LateBound::new().field_a(String::new()).field_b(200).build();
+    assert_eq!(l.get_b(), 200);
 }
 
 fn main() {
-    let i = Inferred::new().b(String::new()).a("5").build();
+    with();
+    without();
 }

--- a/builder-pattern/examples/default-infer.rs
+++ b/builder-pattern/examples/default-infer.rs
@@ -3,17 +3,16 @@ use std::marker::PhantomData;
 
 #[allow(unused)]
 #[derive(Builder)]
-struct Inferred<A = f64, B = String> {
+struct Inferred<A = f64, B = String, F: FnMut(B) -> B = fn(B) -> B> {
     #[infer(A)]
     a: A,
     #[infer(B)]
     b: B,
-    // #[hidden]
-    #[syntactic_default]
-    #[default(PhantomData)]
-    b_default: PhantomData<B>,
+    #[late_bound_default]
+    #[default(|x| x)]
+    b_default: F,
 }
 
 fn main() {
-    let i = Inferred::new().a(5i32).b(String::new()).build();
+    let i = Inferred::new().b(String::new()).a("5").build();
 }

--- a/builder-pattern/examples/default-infer.rs
+++ b/builder-pattern/examples/default-infer.rs
@@ -1,0 +1,19 @@
+use builder_pattern::Builder;
+use std::marker::PhantomData;
+
+#[allow(unused)]
+#[derive(Builder)]
+struct Inferred<A = f64, B = String> {
+    #[infer(A)]
+    a: A,
+    #[infer(B)]
+    b: B,
+    // #[hidden]
+    #[syntactic_default]
+    #[default(PhantomData)]
+    b_default: PhantomData<B>,
+}
+
+fn main() {
+    let i = Inferred::new().a(5i32).b(String::new()).build();
+}

--- a/builder-pattern/examples/default.rs
+++ b/builder-pattern/examples/default.rs
@@ -1,6 +1,7 @@
 use builder_pattern::Builder;
 use uuid::Uuid;
 
+#[allow(unused)]
 #[derive(Builder, Debug)]
 struct Test {
     #[default(String::from("Jack"))]

--- a/builder-pattern/examples/documentation.rs
+++ b/builder-pattern/examples/documentation.rs
@@ -17,6 +17,7 @@ use builder_pattern::Builder;
 ///
 /// println!("{:?}", person);
 /// ```
+#[allow(unused)]
 #[derive(Builder, Debug)]
 struct Person {
     /**

--- a/builder-pattern/examples/fail-visibility1.rs
+++ b/builder-pattern/examples/fail-visibility1.rs
@@ -3,12 +3,14 @@ mod test {
 
     // Private structure
     #[derive(Builder, Debug)]
-    struct PrivateTest {
+    pub struct PrivateTest {
         pub a: i32,
         pub b: &'static str,
         c: i32,
     }
 }
+
+use test::*;
 
 pub fn main() {
     let t1 = PrivateTest::new().a(333).c(1.234).b("hello").build();

--- a/builder-pattern/examples/into-with-default.rs
+++ b/builder-pattern/examples/into-with-default.rs
@@ -1,0 +1,25 @@
+use std::any::TypeId;
+
+use builder_pattern::Builder;
+
+#[allow(unused)]
+#[derive(Builder)]
+struct Test<T = f64> {
+    // Note that without the #[infer(T)], we would still have T = f64 from the
+    // type param default.
+    // The setter method will have a `T_` parameter, and return a TestBuilder<T_, ...>.
+    #[infer(T)]
+    #[into]
+    vector: Vec<T>,
+}
+
+fn main() {
+    let _ = Test::new().vector(&b"byte slice"[..]).build();
+
+    // in more detail:
+    // we can't use a mutable builder and re-assign it, because they are different types.
+    let builder = Test::new();
+    let builder = builder.vector::<u8, _>(&b"hello"[..]);
+    let t = builder.build();
+    assert_eq!(std::any::Any::type_id(&t.vector), TypeId::of::<Vec<u8>>());
+}

--- a/builder-pattern/examples/visibility1.rs
+++ b/builder-pattern/examples/visibility1.rs
@@ -2,6 +2,7 @@ mod test {
     use builder_pattern::Builder;
 
     // Public structure
+    #[allow(unused)]
     #[derive(Builder, Debug)]
     pub struct PublicTest {
         pub a: i32,

--- a/builder-pattern/examples/visibility2.rs
+++ b/builder-pattern/examples/visibility2.rs
@@ -3,6 +3,7 @@ mod test {
 
     // Public structure
     #[derive(Builder, Debug)]
+    #[allow(unused)]
     pub struct PublicTest {
         pub a: i32,
         pub b: Option<i32>,

--- a/builder-pattern/src/lib.rs
+++ b/builder-pattern/src/lib.rs
@@ -648,3 +648,6 @@ pub use builder_pattern_macro::Builder;
 
 #[doc(hidden)]
 pub mod setter;
+
+#[doc(hidden)]
+pub mod refl;

--- a/builder-pattern/src/refl.rs
+++ b/builder-pattern/src/refl.rs
@@ -1,0 +1,60 @@
+//! https://github.com/Centril/refl
+//!
+//! Used under the MIT license. Just the basics.
+
+use core::marker::PhantomData;
+use core::mem;
+
+///
+/// ```compile_fail
+/// use builder_pattern::refl::Id;
+/// let id = Id::<String, Vec<i32>>::REFL;
+/// ```
+///
+/// ```
+/// use builder_pattern::refl::{refl, Id};
+/// fn get_i32<T>(t: T, id: Id<T, i32>) -> i32 {
+///     id.cast(t)
+/// }
+/// let five = get_i32(5, refl());
+/// assert_eq!(five, 5i32);
+/// ```
+///
+pub struct Id<S: ?Sized, T: ?Sized>(PhantomData<(fn(S) -> S, fn(T) -> T)>);
+
+impl<T: ?Sized> Id<T, T> {
+    pub const REFL: Self = Id(PhantomData);
+}
+
+pub fn refl<T: ?Sized>() -> Id<T, T> {
+    Id::REFL
+}
+
+impl<S: ?Sized, T: ?Sized> Id<S, T> {
+    /// Casts a value of type `S` to `T`.
+    ///
+    /// This is safe because the `Id` type is always guaranteed to
+    /// only be inhabited by `Id<T, T>` types by construction.
+    pub fn cast(self, value: S) -> T
+    where
+        S: Sized,
+        T: Sized,
+    {
+        unsafe {
+            // Transmute the value;
+            // This is safe since we know by construction that
+            // S == T (including lifetime invariance) always holds.
+            let cast_value = mem::transmute_copy(&value);
+
+            // Forget the value;
+            // otherwise the destructor of S would be run.
+            mem::forget(value);
+
+            cast_value
+        }
+    }
+    /// Converts `Id<S, T>` into `Id<T, S>` since type equality is symmetric.
+    pub fn sym(self) -> Id<T, S> {
+        Id(PhantomData)
+    }
+}

--- a/builder-pattern/src/setter.rs
+++ b/builder-pattern/src/setter.rs
@@ -4,12 +4,7 @@ use futures::future::LocalBoxFuture;
 use super::refl::Id;
 
 pub enum Setter<'a, T, D = T> {
-    // Initially, T = D.
-    // If you set a value with an #[infer(T)] setter,
-    // then T gets replaced with an inferred type, and we
-    // no longer _know_ that T = D. It could still be.
-    // But we will store a Setter::Value, so the Id<T, D> is gone.
-    Default(T, Id<T, D>),
+    Default(D),
     Value(T),
     Lazy(Box<dyn 'a + FnOnce() -> T>),
     LazyValidated(Box<dyn 'a + FnOnce() -> Result<T, &'static str>>),

--- a/builder-pattern/src/setter.rs
+++ b/builder-pattern/src/setter.rs
@@ -1,7 +1,15 @@
 #[cfg(feature = "future")]
 use futures::future::LocalBoxFuture;
 
-pub enum Setter<'a, T> {
+use super::refl::Id;
+
+pub enum Setter<'a, T, D = T> {
+    // Initially, T = D.
+    // If you set a value with an #[infer(T)] setter,
+    // then T gets replaced with an inferred type, and we
+    // no longer _know_ that T = D. It could still be.
+    // But we will store a Setter::Value, so the Id<T, D> is gone.
+    Default(T, Id<T, D>),
     Value(T),
     Lazy(Box<dyn 'a + FnOnce() -> T>),
     LazyValidated(Box<dyn 'a + FnOnce() -> Result<T, &'static str>>),

--- a/builder-pattern/src/setter.rs
+++ b/builder-pattern/src/setter.rs
@@ -4,7 +4,8 @@ use futures::future::LocalBoxFuture;
 use super::refl::Id;
 
 pub enum Setter<'a, T, D = T> {
-    Default(D),
+    Default(D, Id<D, T>),
+    LateBoundDefault(Id<D, T>),
     Value(T),
     Lazy(Box<dyn 'a + FnOnce() -> T>),
     LazyValidated(Box<dyn 'a + FnOnce() -> Result<T, &'static str>>),

--- a/test-no-future/examples/empty.rs
+++ b/test-no-future/examples/empty.rs
@@ -1,0 +1,6 @@
+use builder_pattern::Builder;
+
+#[derive(Builder)]
+struct Thing {}
+
+fn main() {}

--- a/test-no-future/examples/empty.rs
+++ b/test-no-future/examples/empty.rs
@@ -3,4 +3,6 @@ use builder_pattern::Builder;
 #[derive(Builder)]
 struct Thing {}
 
-fn main() {}
+fn main() {
+    let _: Thing = Thing::new().build();
+}


### PR DESCRIPTION
This adds quite a lot of functionality. The intended use case was a struct like this. It obviously has a problem because if you do not specify `update` or `specialized_initial`, then the compiler doesn't know what type they should be. This is because the macro was not utilising the default type params (which provide fn-pointers, which are enough to compile with since they're never executed because they're None).

```rust
#[derive(Builder)]
pub struct ClosureFold<K, V, R, FAdd, FRemove,
    FUpdate = for<'a> fn(R, &'a K, &'a V, &'a V) -> R,
    FInitial = for<'a> fn(R, &::im_rc::OrdMap<K, V>) -> R
> where
    FAdd: for<'a> FnMut(R, &'a K, &'a V) -> R + 'static,
    FRemove: for<'a> FnMut(R, &'a K, &'a V) -> R + 'static,
    FUpdate: for<'a> FnMut(R, &'a K, &'a V, &'a V) -> R + 'static,
    FInitial: for<'a> FnMut(R, &::im_rc::OrdMap<K, V>) -> R + 'static,
{
    pub add: FAdd,
    pub remove: FRemove,
    #[default(None)]
    pub update: Option<FUpdate>,
    #[default(None)]
    pub specialized_initial: Option<FInitial>,
    #[default(false)]
    pub revert_to_init_when_empty: bool,
    #[default(PhantomData)]
    #[hidden]
    pub phantom: PhantomData<(K, V, R)>,
}
```

The solution required a bunch of changes:

1. Make the `fn new()` return a builder with the default types substituted in their spots.
2. When you provide `update`, the FUpdate closure type can be different from the default. Hence you need to get the setter method to infer the FUpdate, and replace it in the return type. This is done using `fn update<FUpdate_>(update: FUpdate_)` and doing lots of substitutions on the bounds / generic params.
3. However, because you don't know what shape the field type will be, you need to tell the macro which params to do this with. Hence there's a new `#[infer(T1, T2)]` param. For this example you apply it to the update and specialized_initial fields, with `#[infer(FUpdate)]` and `#[infer(FInitial)]` respectively.
4. Lots of minor improvements, much of it relating to commas and macro edge cases.
5. Finally, an extra feature for fields like `phantom: PhantomData<T>` where T was specified with a default type `T = f64` + a separate `#[infer(T)]` field. It needed special handling because if the macro writes a PhantomData in the `fn new()`, then it has to write another one with the inferred T_ (which means a different `PhantomData<T_>` type needs to be in the phantom field. So I introduced "late binding" of defaults, where they are only populated in the `fn build()` function, but the types are carried along the way. This required simple compile-time reflection in the form of the `refl` crate, which I pulled a few select functions from, in order to prove that if you still had a `Some(Setter::LateBoundDefault)` in the field, that basically `T = T_`. It worked pretty well!
6. Late binding is applied by default to `#[hidden]` fields. It also needed some way of doing it while also generating a setter method, so I made `#[late_bound_default]`, but it might need a better name.

Altogether it needs some more docs, and I want to split out some of the example code, but the rest of it should be reviewable.